### PR TITLE
docs: fix link to code of conduct in main readme.md

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -19,7 +19,7 @@ Some organisations use components already available in the NL Design System ecos
 
 ## Code of Conduct
 
-We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community. Read [our Code of Conduct](CODE_OF_CONDUCT.md) if you haven't already.
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community. Read [our Code of Conduct](../CODE_OF_CONDUCT.md) if you haven't already.
 
 ## License
 


### PR DESCRIPTION
It seems the location of CODE_OF_CONDUCT.MD was changed in commit [b8da0633c7fd88a434d3a15337c9f50919f458a1](https://github.com/nl-design-system/.github/commit/b8da0633c7fd88a434d3a15337c9f50919f458a1), but the link in the main readme.md wasn't updated to account for this. This has now been fixed :)